### PR TITLE
Using datatypes, expect <name>ToString function to be impl

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -492,6 +492,7 @@ isElmStringType opts elmTypeExpr =
 
 
 toStringSrcTypes :: T.Text -> ElmOptions -> ElmDatatype -> T.Text
+toStringSrcTypes operator opts (ElmDatatype name _) = T.toLower name <> "ToString"
 toStringSrcTypes operator opts (ElmPrimitive (EMaybe argType)) = toStringSrcTypes operator opts argType
 toStringSrcTypes _ _ (ElmPrimitive (EList (ElmPrimitive EChar))) = "identity"
 toStringSrcTypes operator opts (ElmPrimitive (EList argType)) = toStringSrcTypes operator opts argType


### PR DESCRIPTION
Unfortunately this is a compile-time error for Elm and
requires manual implementation, but that's the quickest
fix to support custom types.

cc @mattjbray 