### PR TITLE
Readme: haskell-servant/example-servant-elm

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,7 @@ getBooksByBookId capture_bookId =
 ```
 
 See [`examples`](examples) for a complete usage example, or take a look at
-[mattjbray/servant-elm-example-app](https://github.com/mattjbray/servant-elm-example-app)
-for an example project using this library.
+[`mattjbray/servant-elm-example-app`](https://github.com/mattjbray/servant-elm-example-app) (elm 0.18) or [`haskell-servant/example-servant-elm`](https://github.com/haskell-servant/example-servant-elm) (elm 0.19) for an example project using this library.
 
 ## Development
 


### PR DESCRIPTION
I updated `haskell-servant/example-servant-elm` to work with 0.19. 
https://github.com/haskell-servant/example-servant-elm/pull/8

A link to this repository in the `README.md` would be nice. The current example is based on elm 0.18 (deprecated).