### PR TITLE
mkUrl: Use urlBase for Dynamic case

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -551,7 +551,7 @@ mkUrl opts segments =
   where
     urlBuilder :: Doc
     urlBuilder = case urlPrefix opts of
-      Dynamic -> "Url.Builder.absolute" :: Doc
+      Dynamic -> "Url.Builder.crossOrigin urlBase" :: Doc
       Static url -> "Url.Builder.crossOrigin" <+> dquotes (stext url)
 
     segmentToDoc :: F.Segment EType -> Doc

--- a/test/elm-sources/getOneWithDynamicUrlSource.elm
+++ b/test/elm-sources/getOneWithDynamicUrlSource.elm
@@ -19,7 +19,7 @@ getOne urlBase toMsg =
             , headers =
                 []
             , url =
-                Url.Builder.absolute
+                Url.Builder.crossOrigin urlBase
                     [ "one"
                     ]
                     params


### PR DESCRIPTION
works as:
```
 get urlBase toMsg =
         Http.request
             { method =
                 "GET"
             , headers =
                 []
             , url =
-                Url.Builder.absolute
+                Url.Builder.crossOrigin urlBase
               ...
             }
```
in the case `urlPrefix = Dynamic`.