### PR TITLE
Using the appropriate toString functions for different types

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,6 @@ import Http
 import String
 import Url.Builder
 
-maybeBoolToIntStr : Maybe Bool -> String
-maybeBoolToIntStr mx =
-  case mx of
-    Nothing -> ""
-    Just True -> "1"
-    Just False -> "0"
-
 type alias Book  =
    { name: String
    }

--- a/examples/books/elm/Generated/BooksApi.elm
+++ b/examples/books/elm/Generated/BooksApi.elm
@@ -10,13 +10,6 @@ import Http
 import String
 import Url.Builder
 
-maybeBoolToIntStr : Maybe Bool -> String
-maybeBoolToIntStr mx =
-  case mx of
-    Nothing -> ""
-    Just True -> "1"
-    Just False -> "0"
-
 type alias Book  =
    { name: String
    }

--- a/examples/e2e-tests/elm/Generated/Api.elm
+++ b/examples/e2e-tests/elm/Generated/Api.elm
@@ -10,13 +10,6 @@ import Http
 import String
 import Url.Builder
 
-maybeBoolToIntStr : Maybe Bool -> String
-maybeBoolToIntStr mx =
-  case mx of
-    Nothing -> ""
-    Just True -> "1"
-    Just False -> "0"
-
 type alias MessageBody  =
    { message: String
    }

--- a/examples/giphy/elm/Generated/GiphyApi.elm
+++ b/examples/giphy/elm/Generated/GiphyApi.elm
@@ -10,13 +10,6 @@ import Http
 import String
 import Url.Builder
 
-maybeBoolToIntStr : Maybe Bool -> String
-maybeBoolToIntStr mx =
-  case mx of
-    Nothing -> ""
-    Just True -> "1"
-    Just False -> "0"
-
 type alias Gif  =
    { data: GifData
    }

--- a/examples/readme-example/my-elm-dir/Generated/MyApi.elm
+++ b/examples/readme-example/my-elm-dir/Generated/MyApi.elm
@@ -10,13 +10,6 @@ import Http
 import String
 import Url.Builder
 
-maybeBoolToIntStr : Maybe Bool -> String
-maybeBoolToIntStr mx =
-  case mx of
-    Nothing -> ""
-    Just True -> "1"
-    Just False -> "0"
-
 type alias Book  =
    { name: String
    }

--- a/src/Servant/Elm.hs
+++ b/src/Servant/Elm.hs
@@ -21,6 +21,7 @@ module Servant.Elm
        , defElmOptions
        , defElmImports
        , defaultOptions
+       , defaultElmToString
        -- * Convenience re-exports from the "Elm" module
        , DefineElm (..)
        , EType (..)
@@ -34,6 +35,7 @@ module Servant.Elm
 
 import           Servant.Elm.Internal.Generate (ElmOptions (..), UrlPrefix (..),
                                                 defElmImports, defElmOptions,
+                                                defaultElmToString,
                                                 generateElmForAPI,
                                                 generateElmForAPIWith,
                                                 generateElmModule,

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -620,7 +620,7 @@ elmListOfMaybes ds = "List.filterMap identity" <$> indent 4 (elmList ds)
 defaultElmToString :: EType -> Text
 defaultElmToString argType =
   case argType of
-    ETyCon (ETCon "Bool")             -> "(\\value -> if value then \"1\" else \"0\")"
+    ETyCon (ETCon "Bool")             -> "(\\value -> if value then \"true\" else \"false\")"
     ETyCon (ETCon "Float")            -> "String.fromFloat"
     ETyCon (ETCon "Char")             -> "String.fromChar"
     ETyApp (ETyCon (ETCon "Maybe")) v -> "(Maybe.map " <> defaultElmToString v <> " >> Maybe.withDefault \"\")"

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -626,10 +626,11 @@ elmListOfMaybes ds = "List.filterMap identity" <$> indent 4 (elmList ds)
 
 defaultElmToString :: EType -> Text
 defaultElmToString argType =
-    case argType of
-    ETyCon (ETCon "Bool")  -> "(\\value -> if value then \"1\" else \"0\")"
-    ETyCon (ETCon "Posix") -> "Time.posixToMillis >> String.fromInt)"
-    _                      -> "String.fromInt"
+  case argType of
+    ETyCon (ETCon "Bool")             -> "(\\value -> if value then \"1\" else \"0\")"
+    ETyCon (ETCon "Posix")            -> "Time.posixToMillis >> String.fromInt)"
+    ETyApp (ETyCon (ETCon "Maybe")) v -> defaultElmToString v
+    _                                 -> "String.fromInt"
 
 toString :: ElmOptions -> EType -> Doc
 toString opts argType =

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -640,17 +640,17 @@ toString opts argType =
 
 pipeLeft :: [Doc] -> Doc
 pipeLeft =
-  encloseSep lbracket rbracket " <| "
+  encloseSep lparen rparen " <| "
 
 pipeRight :: [Doc] -> Doc
 pipeRight =
-  encloseSep lbracket rbracket " |> "
+  encloseSep lparen rparen " |> "
 
 composeLeft :: [Doc] -> Doc
 composeLeft =
-  encloseSep lbracket rbracket " << "
+  encloseSep lparen rparen " << "
 
 composeRight :: [Doc] -> Doc
 composeRight =
-  encloseSep lbracket rbracket " >> "
+  encloseSep lparen rparen " >> "
 

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -53,6 +53,8 @@ data ElmOptions = ElmOptions
     -- ^ Alterations to perform on ETypes before code generation.
   , elmAlterations        :: (ETypeDef -> ETypeDef)
     -- ^ Alterations to perform on ETypeDefs before code generation.
+  , elmToString          :: (EType -> Text)
+    -- ^ Elm functions creating a string from a given type.
   , emptyResponseElmTypes :: [EType]
     -- ^ Types that represent an empty Http response.
   , stringElmTypes        :: [EType]
@@ -87,6 +89,7 @@ defElmOptions = ElmOptions
   { urlPrefix = Static ""
   , elmTypeAlterations = Elm.defaultTypeAlterations
   , elmAlterations = Elm.defaultAlterations
+  , elmToString = defaultElmToString
   , emptyResponseElmTypes =
       [ toElmType (Proxy :: Proxy ())
       ]
@@ -392,15 +395,11 @@ mkLetParams opts request =
           let
             argType = qarg ^. F.queryArgName . F.argType
             wrapped = isElmMaybeType argType
-            -- Don't use "toString" on Elm Strings, otherwise we get extraneous quotes.
             toStringSrc =
-              if isElmStringType opts argType || isElmMaybeStringType opts argType then
-                ""
-              else
-                "String.fromInt >> "
+              toString opts argType
           in
               "[" <+> (if wrapped then elmName else "Just" <+> elmName) <> line <>
-                (indent 4 ("|> Maybe.map" <+> parens (toStringSrc <> "Url.Builder.string" <+> dquotes name)))
+                (indent 4 ("|> Maybe.map" <+> composeRight [toStringSrc, "Url.Builder.string" <+> dquotes name]))
                 <+> "]"
               -- (if wrapped then name else "Just" <+> name) <$>
               -- indent 4 ("|> Maybe.map" <+> parens (toStringSrc <> "Http.encodeUri >> (++)" <+> dquotes (elmName <> equals)) <$>
@@ -464,13 +463,9 @@ mkRequest opts request =
           headerArgName = elmHeaderArg header
           argType = header ^. F.headerArg . F.argType
           wrapped = isElmMaybeType argType
-          toStringSrc =
-            if isElmMaybeStringType opts argType || isElmStringType opts argType then
-              mempty
-            else
-              " << String.fromInt"
+          toStringSrc = toString opts argType
       in
-        "Maybe.map" <+> parens (("Http.header" <+> dquotes headerName <> toStringSrc))
+        "Maybe.map" <+> parens (("Http.header" <+> composeLeft [dquotes headerName, toStringSrc]))
         <+>
         (if wrapped then headerArgName else parens ("Just" <+> headerArgName))
 
@@ -561,14 +556,10 @@ mkUrl opts segments =
           dquotes (stext (F.unPathSegment path))
         F.Cap arg ->
           let
-            -- Don't use "toString" on Elm Strings, otherwise we get extraneous quotes.
-            toStringSrc =
-              if isElmStringType opts (arg ^. F.argType) then
-                empty
-              else
-                " |> String.fromInt"
+            toStringSrc = 
+              toString opts (arg ^. F.argType)
           in
-            (elmCaptureArg s) <> toStringSrc
+            pipeRight [elmCaptureArg s, toStringSrc]
 
 
 mkQueryParams
@@ -632,3 +623,34 @@ elmList ds = lbracket <+> hsep (punctuate (line <> comma) ds) <$> rbracket
 elmListOfMaybes :: [Doc] -> Doc
 elmListOfMaybes [] = lbracket <> rbracket
 elmListOfMaybes ds = "List.filterMap identity" <$> indent 4 (elmList ds)
+
+defaultElmToString :: EType -> Text
+defaultElmToString argType =
+    case argType of
+    ETyCon (ETCon "Bool")  -> "(\\value -> if value then \"1\" else \"0\")"
+    ETyCon (ETCon "Posix") -> "Time.posixToMillis >> String.fromInt)"
+    _                      -> "String.fromInt"
+
+toString :: ElmOptions -> EType -> Doc
+toString opts argType =
+  if isElmStringType opts argType || isElmMaybeStringType opts argType then
+    mempty
+  else
+    stext $ elmToString opts argType
+
+pipeLeft :: [Doc] -> Doc
+pipeLeft =
+  encloseSep lbracket rbracket " <| "
+
+pipeRight :: [Doc] -> Doc
+pipeRight =
+  encloseSep lbracket rbracket " |> "
+
+composeLeft :: [Doc] -> Doc
+composeLeft =
+  encloseSep lbracket rbracket " << "
+
+composeRight :: [Doc] -> Doc
+composeRight =
+  encloseSep lbracket rbracket " >> "
+

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -640,17 +640,16 @@ toString opts argType =
 
 pipeLeft :: [Doc] -> Doc
 pipeLeft =
-  encloseSep lparen rparen " <| "
+  encloseSep lparen rparen " <| " . filter (not . isEmpty)
 
 pipeRight :: [Doc] -> Doc
 pipeRight =
-  encloseSep lparen rparen " |> "
+  encloseSep lparen rparen " |> " . filter (not . isEmpty)
 
 composeLeft :: [Doc] -> Doc
 composeLeft =
-  encloseSep lparen rparen " << "
+  encloseSep lparen rparen " << " . filter (not . isEmpty)
 
 composeRight :: [Doc] -> Doc
 composeRight =
-  encloseSep lparen rparen " >> "
-
+  encloseSep lparen rparen " >> " . filter (not . isEmpty)

--- a/test/GenerateSpec.hs
+++ b/test/GenerateSpec.hs
@@ -70,12 +70,6 @@ spec = do
                               "import Url.Builder\n" <>
                               "import Json.Decode as J\n\n" <>
                               "type alias Book = {}\n\n" <>
-                              "maybeBoolToIntStr : Maybe Bool -> String\n" <>
-                              "maybeBoolToIntStr mx =\n" <>
-                              "  case mx of\n" <>
-                              "    Nothing -> \"\"\n" <>
-                              "    Just True -> \"1\"\n" <>
-                              "    Just False -> \"0\"\n\n" <>
                               "jsonDecBook = J.succeed {}\n\n"
                             )
                           , ( "test/elm-sources/postBooksSource.elm"

--- a/test/elm-sources/getBooksByIdSource.elm
+++ b/test/elm-sources/getBooksByIdSource.elm
@@ -24,7 +24,7 @@ getBooksById capture_id toMsg =
             , url =
                 Url.Builder.crossOrigin ""
                     [ "books"
-                    , capture_id |> String.fromInt
+                    , (capture_id |> String.fromInt)
                     ]
                     params
             , body =

--- a/test/elm-sources/getBooksByTitleSource.elm
+++ b/test/elm-sources/getBooksByTitleSource.elm
@@ -23,7 +23,7 @@ getBooksByTitle capture_title toMsg =
             , url =
                 Url.Builder.crossOrigin ""
                     [ "books"
-                    , capture_title
+                    , (capture_title)
                     ]
                     params
             , body =

--- a/test/elm-sources/getBooksSource.elm
+++ b/test/elm-sources/getBooksSource.elm
@@ -27,7 +27,7 @@ getBooks query_published query_sort query_year query_category query_filters toMs
                 , [ Just query_category
                     |> Maybe.map (Url.Builder.string "category") ]
                 , query_filters
-                    |> List.map ((Maybe.map (\value -> if value then "1" else "0") >> Maybe.withDefault "")
+                    |> List.map ((Maybe.map (\value -> if value then "true" else "false") >> Maybe.withDefault "")
                                  >> Url.Builder.string "filters[]"
                                  >> Just)
                 ])

--- a/test/elm-sources/getBooksSource.elm
+++ b/test/elm-sources/getBooksSource.elm
@@ -7,13 +7,6 @@ import Json.Decode as J
 
 type alias Book = {}
 
-maybeBoolToIntStr : Maybe Bool -> String
-maybeBoolToIntStr mx =
-  case mx of
-    Nothing -> ""
-    Just True -> "1"
-    Just False -> "0"
-
 jsonDecBook = J.succeed {}
 
 getBooks : Bool -> (Maybe String) -> (Maybe Int) -> String -> (List (Maybe Bool)) -> (Result Http.Error  ((List Book))  -> msg) -> Cmd msg
@@ -29,11 +22,14 @@ getBooks query_published query_sort query_year query_category query_filters toMs
                 , [ query_sort
                     |> Maybe.map (Url.Builder.string "sort") ]
                 , [ query_year
-                    |> Maybe.map (String.fromInt >> Url.Builder.string "year") ]
+                    |> Maybe.map (String.fromInt
+                                  >> Url.Builder.string "year") ]
                 , [ Just query_category
                     |> Maybe.map (Url.Builder.string "category") ]
                 , query_filters
-                    |> List.map (\val -> Just (Url.Builder.string "filters[]" (maybeBoolToIntStr val)))
+                    |> List.map ((Maybe.map (\value -> if value then "1" else "0") >> Maybe.withDefault "")
+                                 >> Url.Builder.string "filters[]"
+                                 >> Just)
                 ])
     in
         Http.request

--- a/test/elm-sources/getWithaheaderSource.elm
+++ b/test/elm-sources/getWithaheaderSource.elm
@@ -19,9 +19,11 @@ getWithaheader header_myStringHeader header_MyIntHeader header_MyRequiredStringH
             , headers =
                 List.filterMap identity
                     [ Maybe.map (Http.header "myStringHeader") header_myStringHeader
-                    , Maybe.map (Http.header "MyIntHeader" << String.fromInt) header_MyIntHeader
+                    , Maybe.map (Http.header "MyIntHeader"
+                                 << String.fromInt) header_MyIntHeader
                     , Maybe.map (Http.header "MyRequiredStringHeader") (Just header_MyRequiredStringHeader)
-                    , Maybe.map (Http.header "MyRequiredIntHeader" << String.fromInt) (Just header_MyRequiredIntHeader)
+                    , Maybe.map (Http.header "MyRequiredIntHeader"
+                                 << String.fromInt) (Just header_MyRequiredIntHeader)
                     ]
             , url =
                 Url.Builder.crossOrigin ""


### PR DESCRIPTION
## Problem
If a query param is other than Int or String (like Bool, Float or some custom type), the `String.fromInt` will cause a type error on the Elm side. This is due to the change in Elm 0.19, replacing the polymorphic toString function with several monomorphic ones.

## Solution
Type checking on code generation, inserting the appropriate function.
To support custom types, I added this function as an option to ElmOptions. This way we can use other types like `Time.Posix`:
```Elm
customTypeAlterations :: EType -> EType
customTypeAlterations t =
  case t of
    ETyCon (ETCon "PosixTime") -> ETyCon (ETCon "Posix")
    _ -> t

customToString :: EType -> Text
customToString t =
  case t of
    (ETyCon (ETCon "PosixTime")) -> "(Time.posixToMillis >> String.fromInt)"
    _ -> defaultElmToString t
```

## Problems:
I removed the `maybeBoolToIntStr` function with the new polymorphic one, but if I use the same approach in query params, using "1" as True and "0" as False, I get a parse error on the server side. So I used "true" and "false" instead, but I am not sure, if it would break the original implementation.