### PR TITLE
Improving support for polymorphic data types

### DIFF
--- a/servant-elm.cabal
+++ b/servant-elm.cabal
@@ -48,6 +48,7 @@ test-suite servant-elm-test
   hs-source-dirs:      test
   main-is:             GenerateSpec.hs
   other-modules:       Common
+                     , PolymorphicData
   build-depends:
                        Diff
                      , HUnit

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -420,7 +420,7 @@ mkLetParams opts request =
                         , "Just"
                         ]
                       )
-                        
+
       where
         elmName = elmQueryArg qarg
         name = qarg ^. F.queryArgName . F.argName . to (stext . F.unPathSegment)
@@ -522,6 +522,8 @@ renderDecoderName elmTypeExpr =
       parens ("Json.Decode.list " <> parens (renderDecoderName t))
     ETyApp (ETyCon (ETCon "Maybe")) t ->
       parens ("Json.Decode.maybe " <> parens (renderDecoderName t))
+    ETyApp x y ->
+      parens (renderDecoderName x <+> renderDecoderName y)
     ETyCon (ETCon "Int") -> "Json.Decode.int"
     ETyCon (ETCon "String") -> "Json.Decode.string"
     _ -> ("jsonDec" <> stext (T.pack (renderElm elmTypeExpr)))
@@ -549,7 +551,7 @@ mkUrl opts segments =
           dquotes (stext (F.unPathSegment path))
         F.Cap arg ->
           let
-            toStringSrc = 
+            toStringSrc =
               toString opts (maybeOf (arg ^. F.argType))
           in
             pipeRight [elmCaptureArg s, toStringSrc]

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -15,7 +15,15 @@ data Book = Book
     { title :: String
     }
 
+data PolymorphicData a b = PolymorphicData a b deriving (Show, Eq)
+data SomeRecord = SomeRecord
+  { recordId :: Int
+  , recordName :: String
+  } deriving (Show, Eq)
+
 deriveBoth defaultOptions ''Book
+deriveBoth defaultOptions ''PolymorphicData
+deriveBoth defaultOptions ''SomeRecord
 
 type TestApi =
        "one"

--- a/test/Common.hs
+++ b/test/Common.hs
@@ -15,15 +15,7 @@ data Book = Book
     { title :: String
     }
 
-data PolymorphicData a b = PolymorphicData a b deriving (Show, Eq)
-data SomeRecord = SomeRecord
-  { recordId :: Int
-  , recordName :: String
-  } deriving (Show, Eq)
-
 deriveBoth defaultOptions ''Book
-deriveBoth defaultOptions ''PolymorphicData
-deriveBoth defaultOptions ''SomeRecord
 
 type TestApi =
        "one"

--- a/test/GenerateSpec.hs
+++ b/test/GenerateSpec.hs
@@ -17,7 +17,8 @@ import           Servant.Elm
 import           Test.Hspec                (Spec, describe, hspec, it)
 import           Test.HUnit                (Assertion, assertEqual)
 
-import           Common                    (testApi, SomeRecord(..), PolymorphicData(..))
+import           Common                    (testApi)
+import           PolymorphicData           (SomeRecord(..), PolymorphicData(..))
 
 
 main :: IO ()

--- a/test/PolymorphicData.hs
+++ b/test/PolymorphicData.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+module PolymorphicData where
+
+import Servant.Elm
+
+
+data PolymorphicData a b = PolymorphicData a b deriving (Show, Eq)
+data SomeRecord = SomeRecord
+  { recordId :: Int
+  , recordName :: String
+  } deriving (Show, Eq)
+
+deriveBoth defaultOptions ''PolymorphicData
+deriveBoth defaultOptions ''SomeRecord

--- a/test/elm-sources/getPolymorphicData.elm
+++ b/test/elm-sources/getPolymorphicData.elm
@@ -1,0 +1,43 @@
+module GetPolymorphicData exposing (..)
+
+import Http
+import Json.Decode exposing (..)
+import Url.Builder
+
+type PolymorphicData a b = PolymorphicData a b
+type SomeRecord = SomeRecord { recordId : Int, recordname : String }
+
+jsonDecPolymorphicData : Json.Decode.Decoder a -> Json.Decode.Decoder b -> Json.Decode.Decoder (PolymorphicData a b)
+jsonDecPolymorphicData _ _ = Debug.todo "finish"
+
+jsonDecSomeRecord : Json.Decode.Decoder SomeRecord
+jsonDecSomeRecord = Debug.todo "finish"
+
+
+getPolymorphicData : (Result Http.Error  ((PolymorphicData (List String) SomeRecord))  -> msg) -> Cmd msg
+getPolymorphicData toMsg =
+    let
+        params =
+            List.filterMap identity
+            (List.concat
+                [])
+    in
+        Http.request
+            { method =
+                "GET"
+            , headers =
+                []
+            , url =
+                Url.Builder.crossOrigin ""
+                    [ "polymorphicData"
+                    ]
+                    params
+            , body =
+                Http.emptyBody
+            , expect =
+                Http.expectJson toMsg ((jsonDecPolymorphicData (Json.Decode.list (Json.Decode.string))) jsonDecSomeRecord)
+            , timeout =
+                Nothing
+            , tracker =
+                Nothing
+            }


### PR DESCRIPTION
Hi!

First off: I'm a huge fan of this library.

In a recent project I encountered a problem where the generated API code for an endpoint which returned an (Either [String] Identifier) was being compiled to:

`, expect = jsonDec(Either (List String) Identifier)
`
which fails to compile.  This pull request changes the output in this case to:

`, expect = Http.expectJson toMsg ((jsonDecEither (Json.Decode.list (Json.Decode.string))) jsonDecIdentifier)`

which matches with the generated decoder.

I built the repo referenced in #58 both as-is and using the changes from this repo and the compilation issue there seems to have gone away.