### PR TITLE
apply elmTypeAlterations in ops in Generate.mkRequest

### DIFF
--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -496,14 +496,14 @@ mkRequest opts request =
     expect =
       case request ^. F.reqReturnType of
         Just elmTypeExpr
-          | isEmptyType opts elmTypeExpr
+          | isEmptyType opts $ (elmTypeAlterations opts) elmTypeExpr
             -- let elmConstructor = T.pack (renderElm elmTypeExpr)
            ->
             "Http.expectString " <> line <+> indent i "(\\x -> case x of" <> line <+>
             indent i "Err e -> toMsg (Err e)" <> line <+>
             indent i "Ok _ -> toMsg (Ok ()))"
         Just elmTypeExpr ->
-          "Http.expectJson toMsg" <+> renderDecoderName elmTypeExpr
+          "Http.expectJson toMsg" <+> renderDecoderName ((elmTypeAlterations opts) elmTypeExpr)
         Nothing -> error "mkHttpRequest: no reqReturnType?"
       -- case request ^. F.reqReturnType of
       --   Just elmTypeExpr | isEmptyType opts elmTypeExpr ->


### PR DESCRIPTION
Even if you customize `elmTypeAlteration` of `ElmOptions`,  `generateElmForAPIWith` never notices about the change and thus the request part of generated elm code tries to call `jsonDecFoo`, where  `Foo` is the datatype altered, which is never defined.
This pull request fixes it.