### PR TITLE
precentEncode paths that are passed as captures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Install Nix
+      uses: cachix/install-nix-action@v20
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+
     - name: Cache
       uses: actions/cache@v3
       env:

--- a/src/Servant/Elm/Internal/Generate.hs
+++ b/src/Servant/Elm/Internal/Generate.hs
@@ -119,6 +119,7 @@ The default required imports are:
 > import Set
 > import Http
 > import String
+> import Url
 > import Url.Builder
 -}
 defElmImports :: Text
@@ -132,6 +133,7 @@ defElmImports =
     , "import Set"
     , "import Http"
     , "import String"
+    , "import Url"
     , "import Url.Builder"
     ]
 
@@ -563,7 +565,7 @@ mkUrl opts segments =
             toStringSrc =
               toString opts (maybeOf (arg ^. F.argType))
           in
-            pipeRight [elmCaptureArg s, toStringSrc]
+            "Url.percentEncode " <> pipeRight [elmCaptureArg s, toStringSrc]
 
 
 mkQueryParams

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,3 +3,7 @@ packages:
 - '.'
 flags: {}
 extra-package-dbs: []
+nix:
+  enable: true
+  packages:
+  - zlib

--- a/test/elm-sources/getBooksByIdSource.elm
+++ b/test/elm-sources/getBooksByIdSource.elm
@@ -24,7 +24,8 @@ getBooksById capture_id toMsg =
             , url =
                 Url.Builder.crossOrigin ""
                     [ "books"
-                    , (capture_id |> String.fromInt)
+                    , Url.percentEncode (capture_id
+                                         |> String.fromInt)
                     ]
                     params
             , body =

--- a/test/elm-sources/getBooksByTitleSource.elm
+++ b/test/elm-sources/getBooksByTitleSource.elm
@@ -23,7 +23,7 @@ getBooksByTitle capture_title toMsg =
             , url =
                 Url.Builder.crossOrigin ""
                     [ "books"
-                    , (capture_title)
+                    , Url.percentEncode (capture_title)
                     ]
                     params
             , body =


### PR DESCRIPTION
Captured paths didn't get percent encoded, so if someone includes `/` in the path, it will lead to the wrong route.